### PR TITLE
Add compatibility with Lichess PGNs (support for multiple games, support for move nits)

### DIFF
--- a/pgn_parser/parser.peg
+++ b/pgn_parser/parser.peg
@@ -2,10 +2,13 @@ grammar PGN
 
 # PGN Spec: http://www.saremba.de/chessgml/standards/pgn/pgn-complete.htm
 # Representation of a full game in pgn format, tag_pairs, movetext and score
+
+games <- game+ %make_games
+
 game <- tag_pairs:tag_pairs [\n]? gcomment:comment? movetext:movetext score:score? [\s]* %make_game
 
 # A tag pair is a key, value store in the form [Key "Value"]
-tag_pairs <- tag_pair* %make_tag_pairs
+tag_pairs <- tag_pair+ %make_tag_pairs
 tag_pair <- "[" dlm key dlm "\"" value "\"" dlm "]" dlm %make_tag_pair
 key <- [A-Za-z0-9_]+
 value <- [^\"]*
@@ -35,7 +38,9 @@ blacks_move <- ".."
 
 # A NAG is a numeric annotation glyph, representing anontations on a move such as !! ($3)
 nags <- nag+
-nag <- "$" [0-9]+ dlm
+nag <- ("$" [0-9]+ / symbolic_nag) dlm
+symbolic_nag <- "!!" / "??" / "!?" / "?!" / "!" / "?"
+
 
 # A var or variation is a list of one or more moves surrounded by ()
 variations <- variation+ %make_variations

--- a/pgn_parser/pgn.py
+++ b/pgn_parser/pgn.py
@@ -109,6 +109,9 @@ class Actions:
             s = Score('*')
         g = Game(e[0], e[2], e[3], s)
         return g
+    
+    def make_games(self, input, start, end, elements):
+        return [e for e in elements]
 
 
 class PGNGameException(Exception):


### PR DESCRIPTION
The code now supports parsing multiple games and moves such as " 2. f4?! { [%eval -0.26] } "

Known issues:

The move parsing code will still (just like in the upstream repo) inconsistently parse lines like this:
```
1. e4 { [%eval 0.25] } 1... e5 { [%eval 0.3] } 2. f4?! { [%eval -0.26] } 2... exf4 { [%eval -0.24] } 3. Nf3 { [%eval -0.29] } 3... Be7 { [%eval -0.24] } 
```
The issue is that the move number is repeated twice and thus the moves aren't grouped together like they should be.

The performance of this code is still slower than python-chess's PGN parse.